### PR TITLE
Added -loader suffix to both examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ To make CSS modules work with Webpack you only have to include the modules menti
 . . .
 {
   test: /\.css$/,
-  loader: 'style!css-loader?modules&importLoaders=1&localIdentName=[name]__[local]___[hash:base64:5]' 
+  loader: 'style-loader!css-loader?modules&importLoaders=1&localIdentName=[name]__[local]___[hash:base64:5]' 
 }
 . . .
 ```


### PR DESCRIPTION
With webpack the `-loader` bit in the loader name is optional and even configurable, but nobody needs to know that to get started.

I think mixing usage of the optional-ness of it will confuse people, so this example's string should either both have -loader or neither. This MR adds -loader.
